### PR TITLE
Add NameNode service to the DFS

### DIFF
--- a/Common/Enums/Services.cs
+++ b/Common/Enums/Services.cs
@@ -11,5 +11,7 @@ namespace BareDFS.Common
         GetBlockSize,
         PutBlock,
         GetBlock,
+        Heartbeat,
+        Ping
     }
 }

--- a/Common/Models/DataNode/DataNodeData.cs
+++ b/Common/Models/DataNode/DataNodeData.cs
@@ -7,6 +7,6 @@ namespace BareDFS.Common
     [Serializable]
     public class DataNodeData
     {
-        public string Data { get; set; }
+        public byte[] Data { get; set; }
     }
 }

--- a/Common/Models/DataNode/ReadRequest.cs
+++ b/Common/Models/DataNode/ReadRequest.cs
@@ -5,6 +5,6 @@ namespace BareDFS.Common
     [Serializable]
     public class DataNodeReadRequest
     {
-        public int BlockId { get; set; }
+        public string BlockId { get; set; }
     }
 }

--- a/Common/Models/DataNode/WriteRequest.cs
+++ b/Common/Models/DataNode/WriteRequest.cs
@@ -1,12 +1,13 @@
 namespace BareDFS.Common
 {
     using System;
+    using System.Collections.Generic;
 
     [Serializable]
     public class DataNodeWriteRequest
     {
-        public int BlockId { get; set; }
+        public string BlockId { get; set; }
         public byte[] Data { get; set; }
-        public NodeAddress[] ReplicationNodes { get; set; }
+        public List<NodeAddress> ReplicationNodes { get; set; }
     }
 }

--- a/Common/Models/NameNode/NameNodeMetaData.cs
+++ b/Common/Models/NameNode/NameNodeMetaData.cs
@@ -1,11 +1,12 @@
 namespace BareDFS.Common
 {
     using System;
+    using System.Collections.Generic;
 
     [Serializable]
     public class NameNodeMetaData
     {
-        public int BlockId { get; set; }
-        public NodeAddress[] BlockAddresses { get; set; }
+        public string BlockId { get; set; }
+        public List<NodeAddress> BlockAddresses { get; set; }
     }
 }

--- a/DFS/DataNode/ConsoleApp/Program.cs
+++ b/DFS/DataNode/ConsoleApp/Program.cs
@@ -2,14 +2,12 @@ namespace BareDFS.DataNode.ConsoleApp
 {
     using CommandLine;
     using System;
-    using System.Net;
-    using System.Net.Sockets;
-    using System.Runtime.Serialization;
     using BareDFS.DataNode.Library;
 
     public class Program
     {
-        private static DataNodeHandler dataNodeHandler = null;
+        private static DataNodeHandler? dataNodeHandler = null;
+
         public static void Main(string[] args)
         {
             if (args.Length < 2)
@@ -31,7 +29,7 @@ namespace BareDFS.DataNode.ConsoleApp
         {
             string dataLocation = args.DataLocation;
             ushort servicePort = args.ServicePort;
-            dataNodeHandler = dataNodeHandler == null ? new DataNodeHandler(dataLocation, servicePort) : dataNodeHandler;
+            dataNodeHandler ??= new DataNodeHandler(dataLocation, servicePort);
 
             try
             {
@@ -41,7 +39,6 @@ namespace BareDFS.DataNode.ConsoleApp
             {
                 Console.WriteLine($"Error: {ex.Message}");
             }
-
         }
 
         static void HandleParseError(IEnumerable<Error> errs)

--- a/DFS/NameNode/ConsoleApp/BareDFS.NameNode.ConsoleApp.csproj
+++ b/DFS/NameNode/ConsoleApp/BareDFS.NameNode.ConsoleApp.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AssemblyName>Namenode</AssemblyName>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.2.0"/>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Library\BareDFS.NameNode.Library.csproj" />
+  </ItemGroup>
+</Project>

--- a/DFS/NameNode/ConsoleApp/InputArgs.cs
+++ b/DFS/NameNode/ConsoleApp/InputArgs.cs
@@ -1,0 +1,19 @@
+namespace BareDFS.NameNode.ConsoleApp
+{
+    using CommandLine;
+
+    public class InputArgs
+    {
+        [Option('p', "port", Default=null, Required = true, HelpText = "Port Number for NameNode Service")]
+        public ushort ServicePort { get; set; }
+
+        [Option('d', "datanodes", Default=null, Required = true, HelpText = "All the DataNodes Address in the DFS")]
+        public required string DataNodesAddr { get; set; }
+
+        [Option("block-size-in-kb", Default=64, Required = false, HelpText = "Size of the Blockin KB. Default is 64KB")]
+        public ulong BlockSize { get; set; }
+
+        [Option("replication-factor", Default=null, Required = true, HelpText = "Replication Factor for the Data")]
+        public ulong ReplicationFactor { get; set; }
+    }
+}

--- a/DFS/NameNode/Library/BareDFS.NameNode.Library.csproj
+++ b/DFS/NameNode/Library/BareDFS.NameNode.Library.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <PackageId>BareDFS.NameNode.Library</PackageId>
+    <OutputType>Library</OutputType>
+    <RootNamespace>BareDFS.NameNode.Library</RootNamespace>
+    <AssemblyName>BareDFS.NameNode.Library</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <ProjectReference Include="..\..\..\Common\Common.csproj"/>
+  </ItemGroup>
+</Project>

--- a/DFS/NameNode/Library/Models/UnderReplicatedBlocks.cs
+++ b/DFS/NameNode/Library/Models/UnderReplicatedBlocks.cs
@@ -1,0 +1,11 @@
+namespace BareDFS.NameNode.Library
+{
+    using System;
+
+    [Serializable]
+    public class UnderReplicatedBlocks
+    {
+        public string BlockId { get; set; }
+        public Guid HealthyDataNodeId { get; set; }
+    }
+}

--- a/DFS/NameNode/Library/NameNode.cs
+++ b/DFS/NameNode/Library/NameNode.cs
@@ -1,0 +1,319 @@
+namespace BareDFS.NameNode.Library
+{
+    using BareDFS.Common;
+    using Newtonsoft.Json;
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Sockets;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    [Serializable]
+    public class ReDistributeDataRequest
+    {
+        public string DataNodeUri { get; set; }
+    }
+
+    [Serializable]
+    public class NameNode
+    {
+        private NameNodeInstance nameNodeInstance { get; set; }
+
+        public NameNode(NameNodeInstance nameNodeInstance)
+        {
+            this.nameNodeInstance = nameNodeInstance;
+        }
+
+        public bool GetBlockSize(object request, ref ulong reply)
+        {
+            if (request != null)
+            {
+                reply = nameNodeInstance.BlockSize;
+                return true;
+            }
+            return false;
+        }
+
+        public bool GetData(NameNodeReadRequest request, ref List<NameNodeMetaData> reply)
+        {
+            var fileBlocks = nameNodeInstance.FileNameToBlocks[request.FileName];
+            foreach (var block in fileBlocks)
+            {
+                var blockAddresses = new List<NodeAddress>();
+                var targetDataNodeIds = nameNodeInstance.BlockToDataNodeIds[block];
+                foreach (var dataNodeId in targetDataNodeIds)
+                {
+                    blockAddresses.Add(nameNodeInstance.IdToDataNodes[dataNodeId]);
+                }
+                reply.Add(new NameNodeMetaData { BlockId = block, BlockAddresses = blockAddresses });
+            }
+            return true;
+        }
+
+        public bool PutData(NameNodeWriteRequest request, ref List<NameNodeMetaData> reply)
+        {
+            nameNodeInstance.FileNameToBlocks[request.FileName] = new List<string>();
+            var numberOfBlocksToAllocate = (ulong)Math.Ceiling((double)request.FileSize / nameNodeInstance.BlockSize);
+            reply = AllocateBlocks(request.FileName, numberOfBlocksToAllocate);
+            return true;
+        }
+
+        public void BootStrap()
+        {
+            DiscoverDataNodes();
+            Task.Run(() => HeartbeatToDataNodes());
+        }
+
+        private List<NameNodeMetaData> AllocateBlocks(string fileName, ulong numberOfBlocks)
+        {
+            var metadata = new List<NameNodeMetaData>();
+            var dataNodesAvailableCount = (ulong)nameNodeInstance.IdToDataNodes.Count;
+
+            for (ulong i = 0; i < numberOfBlocks; i++)
+            {
+                // Generate a new block id and assign it to the file
+                var blockId = Guid.NewGuid().ToString();
+                nameNodeInstance.FileNameToBlocks[fileName].Add(blockId);
+
+                var blockAddresses = new List<NodeAddress>();
+
+                // Replicate as many blocks as the available datanodes or replication factior, whichever is smaller
+                var replicationFactor = nameNodeInstance.ReplicationFactor > dataNodesAvailableCount ? dataNodesAvailableCount : nameNodeInstance.ReplicationFactor;
+
+                // Get the datanode ids to which the block is to be replicated
+                nameNodeInstance.BlockToDataNodeIds[blockId] = NameNodeUtil.AssignDataNodes(
+                    nameNodeInstance.IdToDataNodes.Keys.ToList(),
+                    replicationFactor);
+                var targetDataNodeIds = nameNodeInstance.BlockToDataNodeIds[blockId];
+
+                foreach (var dataNodeId in targetDataNodeIds)
+                {
+                    blockAddresses.Add(nameNodeInstance.IdToDataNodes[dataNodeId]);
+                }
+
+                metadata.Add(new NameNodeMetaData { BlockId = blockId, BlockAddresses = blockAddresses });
+            }
+
+            return metadata;
+        }
+
+        private void HeartbeatToDataNodes()
+        {
+            while (true)
+            {
+                Thread.Sleep(5000);
+                foreach (var dataNode in nameNodeInstance.IdToDataNodes)
+                {
+                    var nodeAddres = dataNode.Value;
+                    try
+                    {
+                        using (var client = new TcpClient())
+                        {
+                            client.Connect(nodeAddres.Host, nodeAddres.ServicePort);
+                            var response = false;
+                            CallService(client, Services.Heartbeat.ToString(), true, ref response);
+                            if (!response)
+                                Console.WriteLine("No heartbeat response from DataNode {nodeAddres.Host}:{nodeAddres.ServicePort}");
+                        }
+                    }
+                    catch
+                    {
+                        Console.WriteLine($"No heartbeat received from DataNode {nodeAddres.Host}:{nodeAddres.ServicePort}");
+                        bool reply = false;
+                        ReDistributeData(nodeAddres, ref reply);
+                        nameNodeInstance.IdToDataNodes.Remove(dataNode.Key);
+                    }
+                }
+            }
+        }
+
+        private void DiscoverDataNodes()
+        {
+            var listOfDataNodes = nameNodeInstance.IdToDataNodes;
+            string host = "localhost";
+            var pingRequest = new NodeAddress { Host = host, ServicePort = nameNodeInstance.Port };
+
+            if (listOfDataNodes.Count == 0)
+            {
+                Console.WriteLine("No DataNodes specified, discovering ...");
+                int serverPort = 7000;
+
+                while (serverPort < 7050)
+                {
+                    string dataNodeUri = $"{host}:{serverPort}";
+                    try
+                    {
+                        using (var client = new TcpClient())
+                        {
+                            client.Connect(host, serverPort);
+                            Console.WriteLine($"Pinging DataNode {dataNodeUri}");
+                            var response = false;
+                            CallService(client, Services.Ping.ToString(), pingRequest, ref response);
+
+                            if (response == true)
+                            {
+                                Console.WriteLine($"Ack received from {dataNodeUri}");
+                                listOfDataNodes.Add(Guid.NewGuid(), new NodeAddress { Host = host, ServicePort = (ushort)serverPort });
+                            }
+                            else
+                                Console.WriteLine($"No ack received from {dataNodeUri}");
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        // Continue to next port
+                    }
+                    serverPort++;
+                }
+            }
+            else
+            {
+                Console.WriteLine($"Pinging DataNode(s) specified in the input ...");
+                foreach (var dataNode in listOfDataNodes)
+                {
+                    string dataNodeUri = $"{dataNode.Value.Host}:{dataNode.Value.ServicePort}";
+                    try
+                    {
+                        using (var client = new TcpClient())
+                        {
+                            client.Connect(dataNode.Value.Host, dataNode.Value.ServicePort);
+                            Console.WriteLine($"Pinging DataNode {dataNodeUri}");
+                            var response = false;
+                            CallService(client, Services.Ping.ToString(), pingRequest, ref response);
+
+                            if (response == true)
+                                Console.WriteLine($"Ack received from {dataNodeUri}");
+                            else
+                            {
+                                Console.WriteLine($"No ack received from {dataNodeUri}");
+                                listOfDataNodes.Remove(dataNode.Key);
+                            }
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.WriteLine($"Exception in receiving ack from {dataNodeUri}");
+                        Console.WriteLine($"exception: {ex.Message}");
+                        listOfDataNodes.Remove(dataNode.Key);
+                    }
+                    Console.WriteLine($"DataNode ID: {dataNode.Key} at {dataNode.Value.Host}:{dataNode.Value.ServicePort}\n");
+                }
+            }
+
+            nameNodeInstance.IdToDataNodes = listOfDataNodes;
+        }
+
+        public bool ReDistributeData(NodeAddress deadDataNode, ref bool reply)
+        {
+            Console.WriteLine($"DataNode {deadDataNode.Host}:{deadDataNode.ServicePort} is dead, trying to redistribute data");
+            Guid deadDataNodeId;
+
+            // Get the dead datanode id
+            foreach (var dataNode in nameNodeInstance.IdToDataNodes)
+            {
+                var dnAddress = dataNode.Value;
+                if (dnAddress.Host == deadDataNode.Host && dnAddress.ServicePort == deadDataNode.ServicePort)
+                {
+                    deadDataNodeId = dataNode.Key;
+                    break;
+                }
+            }
+
+            nameNodeInstance.IdToDataNodes.Remove(deadDataNodeId);
+
+            // Get the block ids which were assigned to the dead datanode
+            var underReplicatedBlocksList = new List<UnderReplicatedBlocks>();
+            foreach (var blockId in nameNodeInstance.BlockToDataNodeIds.Keys.ToList())
+            {
+                var dnIds = nameNodeInstance.BlockToDataNodeIds[blockId];
+                for (int i = 0; i < dnIds.Count; i++)
+                {
+                    if (dnIds[i] == deadDataNodeId)
+                    {
+                        var healthyDataNodeId = nameNodeInstance.BlockToDataNodeIds[blockId][(i + 1) % dnIds.Count];
+                        underReplicatedBlocksList.Add(new UnderReplicatedBlocks { BlockId = blockId, HealthyDataNodeId = healthyDataNodeId });
+                        nameNodeInstance.BlockToDataNodeIds[blockId].Remove(deadDataNodeId);
+                        break;
+                    }
+                }
+            }
+
+            if (nameNodeInstance.IdToDataNodes.Count < (int)nameNodeInstance.ReplicationFactor)
+            {
+                Console.WriteLine("Replication not possible due to unavailability of sufficient DataNode(s)");
+                return false;
+            }
+
+            // Replicate the under-replicated blocks to the available DataNodes
+            var availableNodes = nameNodeInstance.IdToDataNodes.Keys.ToList();
+
+            foreach (var blockToReplicate in underReplicatedBlocksList)
+            {
+                var blockId = blockToReplicate.HealthyDataNodeId;
+                var healthyDataNodeAddress = nameNodeInstance.IdToDataNodes[blockToReplicate.HealthyDataNodeId];
+                using (var dataNodeInstance = new TcpClient(healthyDataNodeAddress.Host, healthyDataNodeAddress.ServicePort))
+                {
+                    // Get the block contents from the healthy DataNode
+                    var getRequest = new DataNodeReadRequest { BlockId = blockToReplicate.BlockId };
+                    var getReply = new DataNodeData();
+                    CallService(dataNodeInstance, Services.GetBlock.ToString(), getRequest, ref getReply);
+                    var blockContents = getReply.Data;
+
+                    ulong replication = nameNodeInstance.ReplicationFactor - (ulong)nameNodeInstance.BlockToDataNodeIds[blockToReplicate.BlockId].Count;
+                    var targetDataNodeIds = NameNodeUtil.AssignDataNodes(
+                        availableNodes,
+                        replication,
+                        new List<Guid> { blockToReplicate.HealthyDataNodeId });
+                    nameNodeInstance.BlockToDataNodeIds[blockToReplicate.BlockId] = targetDataNodeIds;
+                    var startingDataNode = nameNodeInstance.IdToDataNodes[targetDataNodeIds[0]];
+                    var remainingDataNodes = new List<NodeAddress>();
+
+                    foreach (var id in targetDataNodeIds.Skip(1))
+                    {
+                        remainingDataNodes.Add(nameNodeInstance.IdToDataNodes[id]);
+                    }
+
+                    // Replicate the block to the target DataNodes
+                    using (var targetDataNodeInstance = new TcpClient(startingDataNode.Host, startingDataNode.ServicePort))
+                    {
+                        var putRequest = new DataNodeWriteRequest
+                        {
+                            BlockId = blockToReplicate.BlockId,
+                            Data = blockContents,
+                            ReplicationNodes = remainingDataNodes
+                        };
+
+                        var putReply = "";
+                        CallService(targetDataNodeInstance, Services.PutBlock.ToString(), putRequest, ref putReply);
+                    }
+
+                    Console.WriteLine($"Block {blockToReplicate.BlockId} replication completed for {string.Join(", ", targetDataNodeIds)}");
+                }
+            }
+
+            return true;
+        }
+
+        public static void CallService<TRequest, TReply>(TcpClient client, string serviceMethod, TRequest request, ref TReply reply)
+        {
+            using (var networkStream = client.GetStream())
+            {
+                using (var writer = new StreamWriter(networkStream))
+                {
+                    var jsonRequest = JsonConvert.SerializeObject(new RpcRequest(serviceMethod, request));
+                    writer.WriteLine(jsonRequest);
+                    writer.Flush();
+                }
+
+                using (var reader = new StreamReader(networkStream))
+                {
+                    var jsonResponse = reader.ReadLine();
+                    reply = JsonConvert.DeserializeObject<TReply>(jsonResponse);
+                }
+            }
+        }
+    }
+}

--- a/DFS/NameNode/Library/NameNodeHandler.cs
+++ b/DFS/NameNode/Library/NameNodeHandler.cs
@@ -1,0 +1,132 @@
+namespace BareDFS.NameNode.Library
+{
+    using BareDFS.Common;
+    using Newtonsoft.Json;
+    using System;
+    using System.Collections.Generic;
+    using System.Net;
+    using System.Net.Sockets;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public class NameNodeHandler
+    {
+        private NameNodeInstance nameNodeInstance { get; set; }
+        private NameNode nameNode { get; set; }
+
+        public NameNodeHandler(ushort serverPort, ulong blockSize, ulong replicationFactor, List<string> listOfDataNodes)
+        {
+            nameNodeInstance = new NameNodeInstance(
+                serverPort,
+                blockSize,
+                replicationFactor,
+                listOfDataNodes);
+
+            nameNode = new NameNode(nameNodeInstance);
+        }
+
+        public void StartNameNodeServer()
+        {
+            nameNode.BootStrap();
+
+            var server = new TcpListener(IPAddress.Any, nameNodeInstance.Port);
+
+            try
+            {
+                Console.WriteLine($"Starting NameNode Server ...");
+                server.Start();
+
+                Task.Run(() => AcceptClients(server));
+
+                Console.WriteLine("NameNode daemon started.\n");
+                nameNodeInstance.ReportStatus();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error: {ex.Message}");
+            }
+            finally
+            {
+                server?.Stop();
+            }
+        }
+
+        private async Task AcceptClients(TcpListener listener)
+        {
+            while (true)
+            {
+                var client = await listener.AcceptTcpClientAsync();
+                Task.Run(() => HandleClient(client));
+            }
+        }
+
+        private void HandleClient(TcpClient client)
+        {
+            using (var stream = client.GetStream())
+            using (var reader = new System.IO.StreamReader(stream))
+            using (var jsonReader = new JsonTextReader(reader))
+            {
+                var request = JsonSerializer.Create().Deserialize<RpcRequest>(jsonReader);
+                try
+                {
+                    var response = ExecuteOperation(request);
+                    using (var writer = new System.IO.StreamWriter(stream))
+                    using (var jsonWriter = new JsonTextWriter(writer))
+                    {
+                        JsonSerializer.Create().Serialize(jsonWriter, response);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Error: {ex.Message}\n");
+                }
+                //formatter.Serialize(stream, response);
+            }
+
+            client.Close();
+        }
+
+        private object ExecuteOperation(RpcRequest request)
+        {
+            string operation = request.Operation;
+            var data = request.Data;
+
+            switch (operation)
+            {
+                case "GetData":
+                    List<NameNodeMetaData> getDataReply = new List<NameNodeMetaData>();
+                    if (nameNode.GetData((NameNodeReadRequest)data, ref getDataReply) == true)
+                    {
+                        return getDataReply;
+                    }
+                    else
+                    {
+                        return new Exception("GetData failed.");
+                    }
+                case "WriteData":
+                    List<NameNodeMetaData> writeDataReply = new List<NameNodeMetaData>();
+                    if (nameNode.PutData((NameNodeWriteRequest)data, ref writeDataReply) == true)
+                    {
+                        return writeDataReply;
+                    }
+                    else
+                    {
+                        return new Exception("WriteData failed.");
+                    }
+                case "GetBlockSize":
+                    ulong blockSize = 0;
+                    if (nameNode.GetBlockSize(data, ref blockSize) == true)
+                    {
+                        return blockSize;
+                    }
+                    else
+                    {
+                        return new Exception("GetBlockSize failed.");
+                    }
+                default:
+                    Console.WriteLine($"Invalid Operation: {operation}");
+                    return new NotImplementedException("Invalid Operation on DataNode.");
+            }
+        }
+    }
+}

--- a/DFS/NameNode/Library/NameNodeInstance.cs
+++ b/DFS/NameNode/Library/NameNodeInstance.cs
@@ -1,0 +1,51 @@
+namespace BareDFS.NameNode.Library
+{
+    using BareDFS.Common;
+    using System;
+    using System.Collections.Generic;
+
+    public class NameNodeInstance
+    {
+        public ushort Port { get; set; }
+        public ulong BlockSize { get; set; }
+        public ulong ReplicationFactor { get; set; }
+        public Dictionary<Guid, NodeAddress> IdToDataNodes { get; set; } = new Dictionary<Guid, NodeAddress>();
+        public Dictionary<string, List<string>> FileNameToBlocks { get; set; } = new Dictionary<string, List<string>>();
+        public Dictionary<string, List<Guid>> BlockToDataNodeIds { get; set; } = new Dictionary<string, List<Guid>>();
+
+        public NameNodeInstance(ushort serverPort, ulong blockSize, ulong replicationFactor, List<string> listOfDataNodes)
+        {
+            BlockSize = blockSize;
+            ReplicationFactor = replicationFactor;
+            Port = serverPort;
+
+            foreach (var dataNode in listOfDataNodes)
+            {
+                var dataNodeParts = dataNode.Split(':');
+                var dataNodeAddress = new NodeAddress
+                {
+                    Host = dataNodeParts[0],
+                    ServicePort = ushort.Parse(dataNodeParts[1])
+                };
+                IdToDataNodes.Add(Guid.NewGuid(), dataNodeAddress);
+            }
+        }
+
+        public void ReportStatus()
+        {
+            Console.WriteLine($"NameNode instance is running on port {Port} with block size {BlockSize} KB and replication factor {ReplicationFactor}\n");
+
+            if (IdToDataNodes.Count == 0)
+            {
+                Console.WriteLine("No DataNodes are in service with the NameNode");
+                return;
+            }
+
+            Console.WriteLine($"The list of DataNode(s) are:");
+            foreach (var dataNode in IdToDataNodes)
+            {
+                Console.WriteLine($"DataNode ID: {dataNode.Key} at {dataNode.Value.Host}:{dataNode.Value.ServicePort}");
+            }
+        }
+    }
+}

--- a/DFS/NameNode/Library/NameNodeUtil.cs
+++ b/DFS/NameNode/Library/NameNodeUtil.cs
@@ -1,0 +1,49 @@
+namespace BareDFS.NameNode.Library
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    public static class NameNodeUtil
+    {
+        // utility method to validate a file path
+        public static bool IsValidFilePath(string filePath)
+        {
+            return !string.IsNullOrEmpty(filePath) && filePath.StartsWith("/");
+        }
+
+        // utility method to format a file path
+        public static string FormatFilePath(string filePath)
+        {
+            return filePath.Trim().Replace("\\", "/");
+        }
+
+        public static void LogMessage(string message)
+        {
+            Console.WriteLine($"[NameNode] {message}");
+        }
+
+        // Utility method to select random numbers from a list as many as specified by count
+        public static List<Guid> SelectRandomNumbers(List<Guid> availableItems, ulong count, List<Guid> dataNodesToExclude = null)
+        {
+            var randomNumberSet = new HashSet<Guid>();
+            var rand = new Random();
+
+            while ((ulong)randomNumberSet.Count < count)
+            {
+                var chosenItem = availableItems[rand.Next(availableItems.Count)];
+                if (dataNodesToExclude != null && dataNodesToExclude.Contains(chosenItem))
+                    continue;
+                randomNumberSet.Add(chosenItem);
+            }
+
+            return randomNumberSet.ToList();
+        }
+
+        public static List<Guid> AssignDataNodes(List<Guid> dataNodesAvailable, ulong replicationFactor, List<Guid> dataNodesToExclude = null)
+        {
+            var targetDataNodeIds = SelectRandomNumbers(dataNodesAvailable, replicationFactor, dataNodesToExclude);
+            return targetDataNodeIds;
+        }
+    }
+}


### PR DESCRIPTION
Add the base logic for the NameNode service.
This includes checking for the given input DataNode addresses and discovering other DataNodes of none is input based on enumerating the different ports and checking for ping response.
The NameNode also periodically (5s) checks for the DataNodes heartbeat and if it fails to get a response, it de-registers the DataNode and does re-replication and re-distribution of the blocks on the failed DataNodes.